### PR TITLE
Extra optimizations (DB-cache estimated value)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ Then run `./manage.py migrate` to create the SQLite database with necessary tabl
 Finally, run `./manage.py runserver 0:8000` to launch the Python webserver.
 
 The site will be accessible via `http://localhost:8000/animals/`
+
+To run tests: `./manage.py test`
+
+# Task Details
+
+A time limit of *3 hours* was imposed on this task.
+
+**Goal**: Build an API endpoint that records animal weights at a given point in time. Build a second endpoint that lets users query estimated weights for a given date (e.g. user has records for Jan 1 and Jan 5, but wants the estimated weight for Jan 3).
+
+Uses Linear Interpolation / Extrapolation to calculate the estimated weight of an anmial for a given datetime timestamp.
+
+# Implementation Notes
+- Used scipy for calculating the Linear Interpolation/Extrapolation due to time constraints and its well-tested implementation. 
+
+- Data is stored in SQLite.
+
+- The estimate_weight endpoint stores the calculated weight in the DB for future, repeated lookups. This acts a sort of cache for the estimated values.
+    - "Cache" busting was not implemented to remove or invalidate the stored estimated weights if new data BEFORE the estimated date was added. E.g if we have a stored estimated weight for Jan 6 and a recorded weight for Jan 5 is added, the Jan 6 estimated weight will still exist even though it could be affected by this new value.
+
+- Project set up is simplified due to 3-hour constraint. Typical installation would use separate settings files for different environments.

--- a/animals/models.py
+++ b/animals/models.py
@@ -10,3 +10,4 @@ class Weight(models.Model):
     animal = models.ForeignKey(Animal, on_delete=models.CASCADE, related_name='weights')
     recorded_weight = models.FloatField()
     recorded_at = models.DateTimeField()
+    estimated = models.BooleanField(default=False)

--- a/animals/tests.py
+++ b/animals/tests.py
@@ -1,8 +1,92 @@
-from django.test import TestCase
+from datetime import datetime
+import pytz
 
-# TESTS TO WRITE:
+from django.test import TransactionTestCase
+from django.urls import reverse
+from django.conf import settings
+from django.utils import timezone
 
-# 1. Ensure animal exists
-# 2. Ensure weights exist for animal if we want estimated weight
-# 3. Try invalid date string in estimated weight (or any invalid url param)
-# 4. Try estimated weight for 1000+ weight recordings
+from rest_framework.test import APIClient
+from rest_framework import status
+
+from animals.models import Animal, Weight
+
+
+class WeightAPITests(TransactionTestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+
+        self.animal = Animal.objects.create(name="Ronald")
+
+        if settings.USE_TZ:
+            self.timezone = pytz.UTC
+        else:
+            self.timezone = None
+
+    def test_no_weights_for_animal(self):
+        """Assert endpoint returns null value when no weights exist for Animal"""
+        requested_date = timezone.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        resp = self.client.get(
+            reverse('animals:estimated_weight', kwargs={'pk': self.animal.id}), 
+            {'date':requested_date}
+        )
+        self.assertIsNone(resp.json()['estimated_weight'])
+
+    def test_invalid_date_for_estimated_weight(self):
+        """Assert error response returned when datetime param in url uses an invalid format"""
+        # Swap Y and m in request datestring
+        requested_date = timezone.now().strftime('%m-%Y-%dT%H:%M:%SZ')
+
+        resp = self.client.get(
+            reverse('animals:estimated_weight', kwargs={'pk': self.animal.id}), 
+            {'date':requested_date}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_estimated_weight_for_animal(self):
+        """ 
+        Assert endpoint returns correct result when trying to estimate weight based on 
+        a date that does not exist in the database.
+        """
+        for i in range(1, 5):
+            weight = float(500) + float(i*2)
+            date_recorded = datetime(2018, 6, i*2, tzinfo=self.timezone)
+
+            # This loop creates these example (Weight, DateRecorded):
+            # (502, (2018, 06, 02))
+            # (504, (2018, 06, 04))
+            # (506, (2018, 06, 08))
+            # (508, (2018, 06, 10))
+
+            Weight.objects.create(
+                animal=self.animal,
+                recorded_weight=weight,
+                recorded_at=date_recorded
+            )
+
+        # Assert a record for 2018-06-07 does NOT exist
+        est_weight = Weight.objects.filter(recorded_at=datetime(2018, 6, 7))
+        self.assertFalse(est_weight.exists())
+
+        # Make request for estimated weight
+        resp = self.client.get(
+            reverse('animals:estimated_weight', kwargs={'pk': self.animal.id}),
+            {'date': datetime(2018, 6, 7).strftime('%Y-%m-%dT%H:%M:%SZ')}
+        )
+
+        # Assert estimated weight is expected value
+        self.assertEqual(resp.json()['estimated_weight'], float(507.0))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Assert estimated weight now stored in DB
+        stored_estimated_weight = Weight.objects.filter(recorded_at=datetime(2018, 6, 7), estimated=True)
+        self.assertTrue(stored_estimated_weight.exists())
+
+    def test_estimated_weight_retrieved_from_db(self):
+        # TODO: Use mock.patch to assert that the endpoint does DB lookup for recorded estimated weight
+        # to see if it exists before running calculation.
+
+        # Apply mock.patch to the interpolate function and assert it is NOT called
+        pass


### PR DESCRIPTION
- Add DB-based caching of estimated weights
    - "Cache" busting was not implemented to remove or invalidate the stored estimated weights if new data BEFORE the estimated date was added. 

        E.g if we have a stored estimated weight for Jan 6 and a recorded weight for Jan 5 is added, the Jan 6 estimated weight will still exist even though it could be affected by this new value.

- Add basic tests